### PR TITLE
OO-923 Unisport CSS fix

### DIFF
--- a/main/src/scss/opintoni/_favorites.scss
+++ b/main/src/scss/opintoni/_favorites.scss
@@ -352,7 +352,6 @@
 
     &__event-name {
       display: flex;
-      flex: 1 100%;
       justify-content: center;
       color: $blue;
       margin-bottom: 0.2em;
@@ -361,7 +360,6 @@
     &__info-row {
       display: flex;
       flex-direction: row;
-      flex: 1 100%;
       margin-top: 0.2em;
 
       &__heading {


### PR DESCRIPTION
Safari breaks with 'flex: 1 100%', but 'flex: 1' is ok, IE breaks if flex is present. All browsers do fine without this flex.

See JIRA ticket for screenshots from desktop browsers, tested also tested with iOS Chrome and Safari.