### PR TITLE
Fixes for editable portfolio headings in teacher portfolios

### DIFF
--- a/portfolio/src/app/directives/editableHeading/editableHeading.directive.js
+++ b/portfolio/src/app/directives/editableHeading/editableHeading.directive.js
@@ -15,7 +15,7 @@
  * along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// MutableHeading is intended for portfolio section headers.
+// EditableHeading is intended for portfolio section headers.
 
 angular.module('directives.editableHeading', [
   'services.portfolio',

--- a/portfolio/src/app/directives/freeTextContent/freeTextContent.directive.js
+++ b/portfolio/src/app/directives/freeTextContent/freeTextContent.directive.js
@@ -98,9 +98,6 @@ angular.module('directives.freeTextContent', [
         }
 
         function isTranslatableHeading() {
-          console.log('in translatableheading: ', scope.headingKey, $translate.instant(scope.headingKey),
-            scope.freeTextContentItem.title
-          );
           return scope.headingKey && $translate.instant(scope.headingKey) === scope.freeTextContentItem.title;
         }
 

--- a/portfolio/src/app/directives/freeTextContent/freeTextContent.directive.js
+++ b/portfolio/src/app/directives/freeTextContent/freeTextContent.directive.js
@@ -43,7 +43,8 @@ angular.module('directives.freeTextContent', [
 
   .directive('freeTextContent', function(FreeTextContentService,
                                          FreeTextContentFactory,
-                                         NG_EMBED_OPTIONS) {
+                                         NG_EMBED_OPTIONS,
+                                         $translate) {
 
     return {
       restrict: 'E',
@@ -96,6 +97,13 @@ angular.module('directives.freeTextContent', [
           });
         }
 
+        function isTranslatableHeading() {
+          console.log('in translatableheading: ', scope.headingKey, $translate.instant(scope.headingKey),
+            scope.freeTextContentItem.title
+          );
+          return scope.headingKey && $translate.instant(scope.headingKey) === scope.freeTextContentItem.title;
+        }
+
         function updateOrCreateNew() {
           var serviceFn;
 
@@ -129,7 +137,8 @@ angular.module('directives.freeTextContent', [
           toggleEdit: function() {
             scope.isEditing = !scope.isEditing;
           },
-          embedOptions: NG_EMBED_OPTIONS
+          embedOptions: NG_EMBED_OPTIONS,
+          isTranslatableHeading: isTranslatableHeading
         });
 
         init();

--- a/portfolio/src/app/directives/freeTextContent/freeTextContent.html
+++ b/portfolio/src/app/directives/freeTextContent/freeTextContent.html
@@ -18,12 +18,14 @@
 <div class="free-text-content ui-component">
   <div class="component-header">
     <h2 ng-if="!isEditing" class="ui-component__title border-bottom">
-        <span ng-if="!headingKey">
-          {{::freeTextContentItem.title}}
-        </span>
-      <span ng-if="headingKey" translate translate-language="{{::portfolioLang}}">
-          {{::headingKey}}
-        </span>
+      <span ng-if="!isTranslatableHeading()">
+        {{::freeTextContentItem.title}}
+      </span>
+
+      <span ng-if="isTranslatableHeading()" translate translate-language="{{::portfolioLang}}">
+        {{::headingKey}}
+      </span>
+
     </h2>
 
     <div ng-if="isEditing">

--- a/portfolio/src/app/directives/studies/studies.html
+++ b/portfolio/src/app/directives/studies/studies.html
@@ -34,7 +34,7 @@
                 maxlength="2500">
       </textarea>
     </div>
-    <div class="studies__summary--view user-text" ng-if="!editing && summary.length">
+    <div class="studies__summary--view user-text" ng-if="!editing && summaryData.length">
       <ng-embed embed-data="summaryData" embed-options="embedOptions"></ng-embed>
     </div>
     <keywords editing="editing" keywords="keywords"></keywords>

--- a/portfolio/src/app/partials/tabs/_administration.html
+++ b/portfolio/src/app/partials/tabs/_administration.html
@@ -21,11 +21,14 @@
       <visibility-toggle section-name="ADMINISTRATION"></visibility-toggle>
     </div>
 
-    <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
-                                          sectionName: 'ADMINISTRATION',
-                                          instanceName: 'GENERAL'}"
-                       portfolio-section="ADMINISTRATION"
-                       instance-name="GENERAL">
-    </free-text-content>
+    <section class="portfolio-section">
+      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+                                            sectionName: 'ADMINISTRATION',
+                                            instanceName: 'GENERAL'}"
+                         portfolio-section="ADMINISTRATION"
+                         instance-name="GENERAL">
+      </free-text-content>
+    </section>
+
   </div>
 </div>

--- a/portfolio/src/app/partials/tabs/_basic_information.html
+++ b/portfolio/src/app/partials/tabs/_basic_information.html
@@ -21,39 +21,48 @@
       <visibility-toggle section-name="BASIC_INFORMATION"></visibility-toggle>
     </div>
 
-    <studies limit-visibility="{componentId: 'STUDIES', sectionName: 'BASIC_INFORMATION'}"
-             summary-data="portfolio.summary"
-             portfolio-id="{{::portfolio.id}}"
-             section-name="BASIC_INFORMATION"
-             heading-key="personalInformation.title"
-             portfolio-lang="{{::portfolio.lang}}">
-    </studies>
+    <section class="portfolio-section">
+      <studies limit-visibility="{componentId: 'STUDIES', sectionName: 'BASIC_INFORMATION'}"
+               summary-data="portfolio.summary"
+               portfolio-id="{{::portfolio.id}}"
+               portfolio-lang="{{::portfolio.lang}}">
+      </studies>
+    </section>
 
-    <language-proficiencies limit-visibility="{componentId: 'LANGUAGE_PROFICIENCIES', sectionName: 'BASIC_INFORMATION'}"
-                            section-name="BASIC_INFORMATION"
-                            language-proficiencies-data="portfolio.languageProficiencies"
-                            portfolio-lang="{{::portfolio.lang}}">
-    </language-proficiencies>
+    <section class="portfolio-section">
+      <language-proficiencies limit-visibility="{componentId: 'LANGUAGE_PROFICIENCIES', sectionName: 'BASIC_INFORMATION'}"
+                              section-name="BASIC_INFORMATION"
+                              language-proficiencies-data="portfolio.languageProficiencies"
+                              portfolio-lang="{{::portfolio.lang}}">
+      </language-proficiencies>
+    </section>
 
-    <work-experience limit-visibility="{componentId: 'WORK_EXPERIENCE', sectionName: 'BASIC_INFORMATION'}"
-                     section-name="BASIC_INFORMATION"
-                     work-experience-data="portfolio.workExperience"
-                     portfolio-id="{{::portfolio.id}}"
-                     portfolio-lang="{{::portfolio.lang}}">
-    </work-experience>
+    <section class="portfolio-section">
+      <work-experience limit-visibility="{componentId: 'WORK_EXPERIENCE', sectionName: 'BASIC_INFORMATION'}"
+                       section-name="BASIC_INFORMATION"
+                       work-experience-data="portfolio.workExperience"
+                       portfolio-id="{{::portfolio.id}}"
+                       portfolio-lang="{{::portfolio.lang}}">
+      </work-experience>
+    </section>
 
-    <degrees limit-visibility="{componentId: 'DEGREES', sectionName: 'BASIC_INFORMATION'}"
-             section-name="BASIC_INFORMATION"
-             degrees-data="portfolio.degrees"
-             portfolio-id="{{::portfolio.id}}"
-             portfolio-lang="{{::portfolio.lang}}">
-    </degrees>
+    <section class="portfolio-section">
+      <degrees limit-visibility="{componentId: 'DEGREES', sectionName: 'BASIC_INFORMATION'}"
+               section-name="BASIC_INFORMATION"
+               degrees-data="portfolio.degrees"
+               portfolio-id="{{::portfolio.id}}"
+               portfolio-lang="{{::portfolio.lang}}">
+      </degrees>
+    </section>
 
-    <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
-                                          sectionName: 'BASIC_INFORMATION',
-                                          instanceName: 'GENERAL'}"
-                       portfolio-section="BASIC_INFORMATION"
-                       instance-name="GENERAL">
-    </free-text-content>
+    <section class="portfolio-section">
+      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+                                            sectionName: 'BASIC_INFORMATION',
+                                            instanceName: 'GENERAL'}"
+                         portfolio-section="BASIC_INFORMATION"
+                         instance-name="GENERAL">
+      </free-text-content>
+    </section>
+
   </div>
 </div>

--- a/portfolio/src/app/partials/tabs/_research.html
+++ b/portfolio/src/app/partials/tabs/_research.html
@@ -21,11 +21,14 @@
       <visibility-toggle section-name="RESEARCH"></visibility-toggle>
     </div>
 
-    <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
-                                          sectionName: 'RESEARCH',
-                                          instanceName: 'GENERAL'}"
-                       portfolio-section="RESEARCH"
-                       instance-name="GENERAL">
-    </free-text-content>
+    <section class="portfolio-section">
+      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+                                            sectionName: 'RESEARCH',
+                                            instanceName: 'GENERAL'}"
+                         portfolio-section="RESEARCH"
+                         instance-name="GENERAL">
+      </free-text-content>
+    </section>
+
   </div>
 </div>

--- a/portfolio/src/app/partials/tabs/_teaching.html
+++ b/portfolio/src/app/partials/tabs/_teaching.html
@@ -23,113 +23,134 @@
 
     <accordion heading-key="teachingTabAccordions.teachingExperience"
                portfolio-lang="{{::portfolio.lang}}">
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'COURSES_TAUGHT'}"
-                         portfolio-section="TEACHING"
-                         instance-name="COURSES_TAUGHT"
-                         heading-key="teachingExperienceAccordionComponents.courses"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
-
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+                           portfolio-section="TEACHING"
+                           instance-name="COURSES_TAUGHT"
+                           heading-key="teachingExperienceAccordionComponents.courses"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'THESIS_SUPERVISION'}"
-                         portfolio-section="TEACHING"
-                         instance-name="THESIS_SUPERVISION"
-                         heading-key="teachingExperienceAccordionComponents.thesisSupervision"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="THESIS_SUPERVISION"
+                           heading-key="teachingExperienceAccordionComponents.thesisSupervision"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
 
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'PRACTICES'}"
-                         portfolio-section="TEACHING"
-                         instance-name="PRACTICES"
-                         heading-key="teachingExperienceAccordionComponents.practices"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="PRACTICES"
+                           heading-key="teachingExperienceAccordionComponents.practices"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
 
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'FEEDBACK'}"
-                         portfolio-section="TEACHING"
-                         instance-name="FEEDBACK"
-                         heading-key="teachingExperienceAccordionComponents.feedback"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="FEEDBACK"
+                           heading-key="teachingExperienceAccordionComponents.feedback"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
     </accordion>
 
     <accordion heading-key="teachingTabAccordions.pedagogicalTraining"
                portfolio-lang="{{::portfolio.lang}}">
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'COURSES_COMPLETED'}"
-                         portfolio-section="TEACHING"
-                         instance-name="COURSES_COMPLETED"
-                         heading-key="pedagogicalTrainingAccordionComponents.courses"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="COURSES_COMPLETED"
+                           heading-key="pedagogicalTrainingAccordionComponents.courses"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
     </accordion>
 
     <accordion heading-key="teachingTabAccordions.materials"
                portfolio-lang="{{::portfolio.lang}}">
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'MATERIALS'}"
-                         portfolio-section="TEACHING"
-                         instance-name="MATERIALS"
-                         heading-key="materialsAccordionComponents.materials"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="MATERIALS"
+                           heading-key="materialsAccordionComponents.materials"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
     </accordion>
 
     <accordion heading-key="teachingTabAccordions.accomplishments"
                portfolio-lang="{{::portfolio.lang}}">
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'CURRICULUM_DESIGN'}"
-                         portfolio-section="TEACHING"
-                         instance-name="CURRICULUM_DESIGN"
-                         heading-key="accomplishmentsAccordionComponents.curriculumDesign"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="CURRICULUM_DESIGN"
+                           heading-key="accomplishmentsAccordionComponents.curriculumDesign"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
 
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'TEACHING_COLLABORATION'}"
-                         portfolio-section="TEACHING"
-                         instance-name="TEACHING_COLLABORATION"
-                         heading-key="accomplishmentsAccordionComponents.collaborativeTeaching"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="TEACHING_COLLABORATION"
+                           heading-key="accomplishmentsAccordionComponents.collaborativeTeaching"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
 
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'AWARDS'}"
-                         portfolio-section="TEACHING"
-                         instance-name="AWARDS"
-                         heading-key="accomplishmentsAccordionComponents.awards"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="AWARDS"
+                           heading-key="accomplishmentsAccordionComponents.awards"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
 
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                             sectionName: 'TEACHING',
                                             instanceName: 'RESEARCH'}"
-                         portfolio-section="TEACHING"
-                         instance-name="RESEARCH"
-                         heading-key="accomplishmentsAccordionComponents.research"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+                           portfolio-section="TEACHING"
+                           instance-name="RESEARCH"
+                           heading-key="accomplishmentsAccordionComponents.research"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
 
-      <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
-                                            sectionName: 'TEACHING',
-                                            instanceName: 'ADVISING'}"
-                         portfolio-section="TEACHING"
-                         instance-name="ADVISING"
-                         heading-key="accomplishmentsAccordionComponents.advising"
-                         portfolio-lang="{{::portfolio.lang}}">
-      </free-text-content>
+      <section class="portfolio-section">
+        <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
+                                              sectionName: 'TEACHING',
+                                              instanceName: 'ADVISING'}"
+                           portfolio-section="TEACHING"
+                           instance-name="ADVISING"
+                           heading-key="accomplishmentsAccordionComponents.advising"
+                           portfolio-lang="{{::portfolio.lang}}">
+        </free-text-content>
+      </section>
     </accordion>
   </div>
 </div>

--- a/portfolio/src/scss/portfolio/_editable.scss
+++ b/portfolio/src/scss/portfolio/_editable.scss
@@ -57,7 +57,7 @@
   .icon--done {
     right: $done-icon-right-offset;
     font-size: $done-icon-size;
-    @include vertically-center
+    @include vertically-center;
     color: $blue;
     &:hover {
       cursor: pointer;

--- a/portfolio/src/scss/portfolio/_portfolio-general.scss
+++ b/portfolio/src/scss/portfolio/_portfolio-general.scss
@@ -23,7 +23,10 @@
       vertical-align: middle;
       margin-right: 0.5em;
     }
-
+  }
+}
+.portfolio:not(.is-preview) .portfolio-section {
+  .ui-component__title {
     &.is-editable {
       display: inline-block;
       padding-right: 2em;
@@ -50,7 +53,7 @@
      text-transform: uppercase;
      font-weight: 700;
      letter-spacing: -0.05em;
-     width: 80%;
+     width: 85%;
    }
   }
 }


### PR DESCRIPTION
Korjaa:
- 'My studies' summary ei ollut muokattavissa
- Tyylitiedot väärät muokatessa otsikoita opettajan portfoliossa
- Jos otsikoita muuttaa opettajan portfolion fiksatuissa vapaateksteissä, käännetty teksti overraidasi muutokset.

 