### PR TITLE
Base clipboard button to library's own evaluation.

### DIFF
--- a/main/src/app/directives/weekFeed/subscribeEvents/subscribeEvents.directive.js
+++ b/main/src/app/directives/weekFeed/subscribeEvents/subscribeEvents.directive.js
@@ -66,7 +66,7 @@ angular.module('directives.subscribeEvents', [
         $scope.showPopover = false;
         $scope.InstructionLinks = InstructionLinks;
         $scope.selectedLanguage = $rootScope.selectedLanguage;
-        $scope.showCopyToClipboard = !BrowserUtil.isMobile();
+        $scope.showCopyToClipboard = Clipboard.isSupported();
 
         $scope.copyToClipboardSuccessCallback = function() {
           $scope.copyToClipboardSuccess = true;


### PR DESCRIPTION
Yhden rivin muutos.

Tarkistin samalla isMobile-funktion käyttöä. Joitakin isMobile-tarkistuksia tulee lähtemään kun opastuskierros otetaan pois, mutta muuten sitä käytetään ihan mielekkäästi: näyttävät vähemmän tavaraa / pienemmän kuvan jos näyttö on kapeampi. Pysyköön. 
