### PR TITLE
OO-952, fix inactive button-like area

### DIFF
--- a/main/src/app/directives/weekFeed/subscribeEvents/subscribeEvents.html
+++ b/main/src/app/directives/weekFeed/subscribeEvents/subscribeEvents.html
@@ -15,7 +15,7 @@
   ~ along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<div>
+<div class="weekfeed-subscribe__container">
   <button class="weekfeed-subscribe__button button text-transform-capitalize"
           ng-click="onClick()"
           translate="weekFeed.subscribeEvents">

--- a/main/src/scss/opintoni/_week-feed.scss
+++ b/main/src/scss/opintoni/_week-feed.scss
@@ -305,6 +305,10 @@ $tablist-single-row: min-width 28.75em;
     width: auto;
   }
 
+  &__container {
+    width: 100%;
+  }
+
   &__button {
     width: 100%;
     padding: 0.3em 0.7em 0.4em;


### PR DESCRIPTION
Korjaa lisämainintana olleen pyynnön tiketissä, mobiilikoossa lisää kalenteri-nappi saa sinisen palkin taakseen, joka näyttää napilta mutta ei olekaan. Nappi venyy nyt peittämään palkin.