### PR TITLE
OO-1056 reordering sections doesn't overlap with mouse select

### DIFF
--- a/main/src/scss/opintoni/_component-header.scss
+++ b/main/src/scss/opintoni/_component-header.scss
@@ -23,6 +23,7 @@
   .component-header__actions {
     margin-left: auto;
     font-size: 1.2em;
+    min-width: 92px;
 
     > * {
       margin-left: 1em;

--- a/main/src/scss/opintoni/_favorites.scss
+++ b/main/src/scss/opintoni/_favorites.scss
@@ -225,22 +225,6 @@
   }
 }
 
-.add-favorite {
-  height: 250px;
-
-  @include breakpoint($small) {
-    height: 280px;
-  }
-
-  @include breakpoint($medium) {
-    height: 320px;
-  }
-
-  @include breakpoint($large) {
-    height: 350px;
-  }
-}
-
 .add-favorite-step {
   width: 100%;
 

--- a/main/src/scss/opintoni/_favorites.scss
+++ b/main/src/scss/opintoni/_favorites.scss
@@ -30,7 +30,6 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  min-height: 120px !important;
 
   @include breakpoint($small) {
     &::after {

--- a/portfolio/src/app/directives/attainments/attainments.html
+++ b/portfolio/src/app/directives/attainments/attainments.html
@@ -28,7 +28,7 @@
     </div>
   </div>
 
-  <ul ng-if="editing">
+  <ul ng-if="editing" class="study-attainments">
     <li class="study-attainment" ng-repeat="attainment in allAttainments">
       <div class="study-attainment__item">
 

--- a/portfolio/src/app/directives/degrees/editDegrees.html
+++ b/portfolio/src/app/directives/degrees/editDegrees.html
@@ -15,7 +15,7 @@
   ~ along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<ul role="list">
+<ul role="list" class="degrees">
   <li class="degree editable" ng-repeat="degree in degrees">
     <div class="degree__item editable">
       <div class="degree__lyre--edit"></div>

--- a/portfolio/src/app/directives/degrees/showDegrees.html
+++ b/portfolio/src/app/directives/degrees/showDegrees.html
@@ -15,7 +15,7 @@
   ~ along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<ul role="list">
+<ul role="list" class="degrees">
   <li class="degree" ng-repeat="degree in degrees">
     <div class="degree__item">
       <div class="degree__lyre"></div>

--- a/portfolio/src/app/partials/_student.html
+++ b/portfolio/src/app/partials/_student.html
@@ -25,7 +25,7 @@
       <section ng-repeat="section in portfolioSections"
                class="portfolio-section"
                as-sortable-item>
-        <div ng-switch on="section.component">
+        <div ng-switch on="section.component" class="portfolio-section__outer-container">
           <span class="portfolio-section__drag-handle" as-sortable-item-handle ></span>
           <div ng-switch-when="STUDIES" class="portfolio-section__body">
             <studies limit-visibility="{componentId: 'STUDIES'}"

--- a/portfolio/src/app/partials/_student.html
+++ b/portfolio/src/app/partials/_student.html
@@ -25,9 +25,9 @@
       <section ng-repeat="section in portfolioSections"
                class="portfolio-section"
                as-sortable-item>
-        <div as-sortable-item-handle
-             ng-switch on="section.component">
-          <div ng-switch-when="STUDIES">
+        <div ng-switch on="section.component">
+          <span class="portfolio-section__drag-handle" as-sortable-item-handle ></span>
+          <div ng-switch-when="STUDIES" class="portfolio-section__body">
             <studies limit-visibility="{componentId: 'STUDIES'}"
                      summary-data="portfolio.summary"
                      portfolio-id="{{::portfolio.id}}"
@@ -35,7 +35,7 @@
             </studies>
           </div>
 
-          <div ng-switch-when="DEGREES">
+          <div ng-switch-when="DEGREES" class="portfolio-section__body">
             <degrees limit-visibility="{componentId: 'DEGREES'}"
                      degrees-data="portfolio.degrees"
                      portfolio-id="{{::portfolio.id}}"
@@ -43,7 +43,7 @@
             </degrees>
           </div>
 
-          <div ng-switch-when="WORK_EXPERIENCE">
+          <div ng-switch-when="WORK_EXPERIENCE" class="portfolio-section__body">
             <work-experience limit-visibility="{componentId: 'WORK_EXPERIENCE'}"
                              work-experience-data="portfolio.workExperience"
                              portfolio-id="{{::portfolio.id}}"
@@ -51,7 +51,7 @@
             </work-experience>
           </div>
 
-          <div ng-switch-when="SAMPLES">
+          <div ng-switch-when="SAMPLES" class="portfolio-section__body">
             <samples limit-visibility="{componentId: 'SAMPLES'}"
                      samples-data="portfolio.samples"
                      portfolio-id="{{::portfolio.id}}"
@@ -59,7 +59,7 @@
             </samples>
           </div>
 
-          <div ng-switch-when="FREE_TEXT_CONTENT">
+          <div ng-switch-when="FREE_TEXT_CONTENT" class="portfolio-section__body">
             <free-text-content limit-visibility="{componentId: 'FREE_TEXT_CONTENT',
                                                   instanceName: section.instanceName}"
                                instance-name="{{section.instanceName}}"
@@ -67,21 +67,21 @@
             </free-text-content>
           </div>
 
-          <div ng-switch-when="ATTAINMENTS">
+          <div ng-switch-when="ATTAINMENTS" class="portfolio-section__body">
             <attainments limit-visibility="{componentId: 'ATTAINMENTS'}"
                          portfolio-id="{{::portfolio.id}}"
                          portfolio-lang="{{::portfolio.lang}}">
             </attainments>
           </div>
 
-          <div ng-switch-when="LANGUAGE_PROFICIENCIES">
+          <div ng-switch-when="LANGUAGE_PROFICIENCIES" class="portfolio-section__body">
             <language-proficiencies limit-visibility="{componentId: 'LANGUAGE_PROFICIENCIES'}"
                                     language-proficiencies-data="portfolio.languageProficiencies"
                                     portfolio-lang="{{::portfolio.lang}}">
             </language-proficiencies>
           </div>
 
-          <div ng-switch-when="FAVORITES">
+          <div ng-switch-when="FAVORITES" class="portfolio-section__body">
             <favorites limit-visibility="{componentId: 'FAVORITES'}"
                        favorites-data="portfolio.favorites"
                        portfolio-lang="{{::portfolio.lang}}">

--- a/portfolio/src/scss/portfolio/_attainments.scss
+++ b/portfolio/src/scss/portfolio/_attainments.scss
@@ -15,6 +15,10 @@
  * along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+.study-attainments {
+  margin-top: 0.5em;
+}
+
 .study-attainment__item {
   @extend .box-data, .border-bottom;
   padding-top: 15px;

--- a/portfolio/src/scss/portfolio/_degrees.scss
+++ b/portfolio/src/scss/portfolio/_degrees.scss
@@ -17,6 +17,10 @@
 
 $degree-invalid-color: red;
 
+.degrees {
+  margin-top: 1em;
+}
+
 .degree__item {
   @extend .box-data, .border-bottom;
   min-height: 94px;

--- a/portfolio/src/scss/portfolio/_language-proficiencies.scss
+++ b/portfolio/src/scss/portfolio/_language-proficiencies.scss
@@ -53,6 +53,8 @@
   flex-direction: column;
   flex-wrap: nowrap;
 
+  margin-top: 1em;
+
   @include breakpoint($medium) {
     flex-direction: row;
     flex-wrap: wrap;

--- a/portfolio/src/scss/portfolio/_portfolio-general.scss
+++ b/portfolio/src/scss/portfolio/_portfolio-general.scss
@@ -15,7 +15,7 @@
  * along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-.portfolio-section > div {
+.portfolio-section__outer-container {
   display: flex;
 }
 
@@ -60,12 +60,12 @@
     }
    &--edit {
      display: inline-block;
-     padding: 0;
+     padding: 0 0.2em;
      font-size: 2.5em;
      text-transform: uppercase;
      font-weight: 700;
      letter-spacing: -0.05em;
-     width: 85%;
+     width: 100%;
    }
   }
 }

--- a/portfolio/src/scss/portfolio/_portfolio-general.scss
+++ b/portfolio/src/scss/portfolio/_portfolio-general.scss
@@ -24,7 +24,7 @@
     margin-top: 1em;
     &:before {
       content: $icon-drag;
-      font-size: 2.5em;
+      font-size: 2.5rem;
       color: $black;
       font-family: "hy-icons";
       vertical-align: middle;

--- a/portfolio/src/scss/portfolio/_portfolio-general.scss
+++ b/portfolio/src/scss/portfolio/_portfolio-general.scss
@@ -15,16 +15,28 @@
  * along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+.portfolio-section > div {
+  display: flex;
+}
+
 .portfolio:not(.is-preview) .portfolio-components__dropzone:not(.drag-disabled) > .portfolio-section {
-  .ui-component__title {
-    &::before {
+  .portfolio-section__drag-handle {
+    margin-top: 1em;
+    &:before {
       content: $icon-drag;
+      font-size: 2.5em;
+      color: $black;
       font-family: "hy-icons";
       vertical-align: middle;
       margin-right: 0.5em;
     }
   }
 }
+
+.portfolio-section__body {
+  flex-grow: 30;
+}
+
 .portfolio:not(.is-preview) .portfolio-section {
   .ui-component__title {
     &.is-editable {


### PR DESCRIPTION
Vain hampurilainen sallii vetämisen. Otsikon kautta vetäminen oli myös ärsyttävää: yritykset maalata portfoliota jos sen haluaa esim. kopioida cv:n pohjaksi eivät toimisi. Lisäksi pikkukorjauksia portfolion muokkauksessa: 

- Lisätty vertikaalista tilaa otsikon ja muokattavan elementin väliin ’Kielitaito’, ’Suoritetut’ ja ’Tutkinnot’ -komponenteissa. 
- Kun lisää uutta suosikkia, valikko ei ole pitkä vertikaalinen palkki vaan vain sen kokoinen kuin tarvitaan.
- Muokattavissa otsikoissa on vähän horisontaalista tilaa muokkauslaatikon ja tekstin väliin.

Toimii opiskelijan ja opettajan puolella, vaikuttaa uuden suosikin lisäykseen myös opintoni-etusivulla ja toimii mobiilikoossa.
