### PR TITLE
Fix OO-1100 default avatar image

### DIFF
--- a/main/Gruntfile.js
+++ b/main/Gruntfile.js
@@ -205,7 +205,8 @@ module.exports = function(grunt) {
           'dist/assets/styles/*.css',
           'dist/assets/fonts/hy-icons.*',
           'dist/assets/images/**/*.{png,ico,jpg}',
-          'dist/assets/icons/**/*.{png,svg}'
+          'dist/assets/icons/**/*.{png,svg}',
+          '!dist/assets/icons/avatar.png'
         ]
       }
     },

--- a/portfolio/Gruntfile.js
+++ b/portfolio/Gruntfile.js
@@ -191,7 +191,8 @@ module.exports = function(grunt) {
           'dist/assets/styles/*.css',
           'dist/assets/fonts/hy-icons.*',
           'dist/assets/images/**/*.{png,ico,jpg}',
-          'dist/assets/icons/**/*.{png,svg}'
+          'dist/assets/icons/**/*.{png,svg}',
+          '!dist/assets/icons/avatar.png'
         ]
       }
     },


### PR DESCRIPTION
Osoite avatar-kuvalle saadaan backendiltä -- myös osoite oletuskuvaan jos oma kuva puuttuu -- ja se ei tiedä frontendin fingerprint-aikeista mitään. Muiden kuin oletusavatarin tapauksessa osoite osoittaa backendin apiin, oletusavatarissa frontendin tarjoamaan tiedostoon. 

Olisi enemmän oikein, jos tämä oletusavatar olisi backendin tarjoama tiedosto, mutta korjataan nyt vain niin, että jätetään oletusavatar-kuva fingerprinttaamatta. Syy on, että epäilen Opinderin ja Mecen myös hakevan oletusavataria tästä frontin osoitteesta.  