### PR TITLE
OO-1105 "Optime-lisätietojen näkymän muokkaus Opintoni kalenteriin" a…

### DIFF
--- a/main/src/app/directives/eventCalendar/eventCalendar.directive.js
+++ b/main/src/app/directives/eventCalendar/eventCalendar.directive.js
@@ -70,6 +70,10 @@ angular.module('directives.eventCalendar', [])
                 allDaySlot: false,
                 eventRender: function(event, element) {
                   element.attr('title', event.tooltip);
+                  if ($scope.calendarView === 'MONTH') {
+                    element.css('overflow', 'hidden');
+                    element.css('height', '48px');
+                  }
                   element.on('click mouseup', function(e) {
                     // catch click events and middle mouse clicks
                     if (AnalyticsService.isClickOrMiddleButton(e)) {
@@ -153,7 +157,7 @@ angular.module('directives.eventCalendar', [])
 
         $scope.eventSources = [];
 
-        function getEventTitle(event) {
+        function getEventTitleWithLocationsAndOptimeExtras(event) {
           var title = event.fullEventTitle;
 
           if (event.locations) {
@@ -162,6 +166,10 @@ angular.module('directives.eventCalendar', [])
                 title += ', ' + location.roomName;
               }
             });
+          }
+
+          if (event.optimeExtrasAsString) {
+            title += '\n' + event.optimeExtrasAsString;
           }
           return title;
         }
@@ -181,7 +189,7 @@ angular.module('directives.eventCalendar', [])
             var startMoment =  event.startDate;
             var endMoment = event.endDate ||
               moment().clone(startMoment).add(CalendarDefaults.EVENT_DURATION_HOURS, 'hours');
-            var title = getEventTitle(event);
+            var title = getEventTitleWithLocationsAndOptimeExtras(event);
 
             return {
               title: title,

--- a/main/src/app/directives/weekFeed/feedItem/event/eventWithImage.html
+++ b/main/src/app/directives/weekFeed/feedItem/event/eventWithImage.html
@@ -31,9 +31,6 @@
     </a>
     <span ng-if="!feedItem.courseUri"><event-title></event-title></span>
   </div>
-  {{:: feedItem.optimeExtras.otherNotes}}
-  {{:: feedItem.optimeExtras.roomNotes}}
-  {{:: feedItem.optimeExtras.staffNotes}}
   <div class="box-data__content">
     <div ng-repeat="location in feedItem.locations" class="event-location">
       <span class="event-location__name">{{ ::location.locationString }}</span>
@@ -47,6 +44,7 @@
       </span>
     </div>
   </div>
+  {{:: feedItem.optimeExtrasAsString}}
 
   <course-materials-link compact="feedItem.showAsChild" feed-item="feedItem"></course-materials-link>
 </div>

--- a/main/src/app/directives/weekFeed/feedItem/event/eventWithoutImage.html
+++ b/main/src/app/directives/weekFeed/feedItem/event/eventWithoutImage.html
@@ -35,9 +35,6 @@
       </a>
       <event-title ng-if="!feedItem.courseUri"></event-title>
     </div>
-    {{:: feedItem.optimeExtras.otherNotes}}
-    {{:: feedItem.optimeExtras.roomNotes}}
-    {{:: feedItem.optimeExtras.staffNotes}}
     <div class="box-data__content">
       <div ng-repeat="location in feedItem.locations" class="event-location">
         <span class="event-location__name">{{::location.locationString }}</span>
@@ -51,6 +48,7 @@
         </span>
       </div>
     </div>
+    {{:: feedItem.optimeExtrasAsString}}
 
   </div>
 </div>


### PR DESCRIPTION
…nd OO-1106 "Opintoni kalenterin Optime-lisätiedot halutaan näyttää Outlookin kalenterin description-kentässä"

- EventDto.fullEventTitle now returns just the title, and Optime extra fields are now in fields optimeExtras and optimeExtrasAsString.
- iCalendar feed now contains Optime extra fields in the Description field.
- Event height is now hardcoded to 48 pixels in the Calendar month view.
- Calendar and List views now show Optime extra fields, in revised order, after title and location data. Separated from each other by commas, and from title/location by a newline.
- Modified local test data in order to see something relevant in the UI.