### PR TITLE
OO-1119 Tools menu CSS bugs

### DIFF
--- a/common/src/scss/styleguide/_styleguide.scss
+++ b/common/src/scss/styleguide/_styleguide.scss
@@ -19,6 +19,7 @@
 
 @import "../bower_components/Styleguide/sass/variables/breakpoints";
 @import "../bower_components/Styleguide/sass/variables/colors";
+//@import "../bower_components/Styleguide/sass/variables/rasters";
 @import "../bower_components/Styleguide/sass/variables/typography";
 
 @import "../bower_components/Styleguide/sass/mixins/angular";
@@ -35,8 +36,9 @@
 @import "../bower_components/Styleguide/sass/mixins/typography";
 @import "../bower_components/Styleguide/sass/mixins/utility";
 
-@import "../bower_components/Styleguide/sass/icons/icons";
+//@import "../bower_components/Styleguide/sass/icons/__icon_font";
 @import "../bower_components/Styleguide/sass/icons/__variables";
+@import "../bower_components/Styleguide/sass/icons/icons";
 
 @import "../bower_components/Styleguide/sass/objects/bar";
 @import "../bower_components/Styleguide/sass/objects/button";
@@ -45,6 +47,8 @@
 @import "../bower_components/Styleguide/sass/objects/misc";
 
 @import "../bower_components/Styleguide/sass/layouts/common/l-footer";
+//@import "../bower_components/Styleguide/sass/layouts/common/l-header-bar";
+//@import "../bower_components/Styleguide/sass/layouts/common/l-overlay";
 @import "../bower_components/Styleguide/sass/layouts/common/l-subregion";
 @import "../bower_components/Styleguide/sass/layouts/common/l-top-bar";
 
@@ -61,30 +65,41 @@
 //@import "../bower_components/Styleguide/sass/components/file";
 //@import "../bower_components/Styleguide/sass/components/form";
 //@import "../bower_components/Styleguide/sass/components/hero";
+//@import "../bower_components/Styleguide/sass/components/highlight";
 //@import "../bower_components/Styleguide/sass/components/horizontal-tabs";
 //@import "../bower_components/Styleguide/sass/components/index";
-//@import "../bower_components/Styleguide/sass/components/job-listing";
+//@import "../bower_components/Styleguide/sass/components/jobs-listing";
 //@import "../bower_components/Styleguide/sass/components/label-row";
+//@import "../bower_components/Styleguide/sass/components/liftup-grid";
+//@import "../bower_components/Styleguide/sass/components/liftup-mosaic";
+//@import "../bower_components/Styleguide/sass/components/liftup";
+//@import "../bower_components/Styleguide/sass/components/link-grid";
 @import "../bower_components/Styleguide/sass/components/links";
 @import "../bower_components/Styleguide/sass/components/list-of-links";
 @import "../bower_components/Styleguide/sass/components/logo";
 @import "../bower_components/Styleguide/sass/components/main-menu";
+//@import "../bower_components/Styleguide/sass/components/media-item";
 @import "../bower_components/Styleguide/sass/components/messages";
+//@import "../bower_components/Styleguide/sass/components/overlay-toggle";
 //@import "../bower_components/Styleguide/sass/components/page-title";
 //@import "../bower_components/Styleguide/sass/components/pager";
 //@import "../bower_components/Styleguide/sass/components/panel";
 //@import "../bower_components/Styleguide/sass/components/post";
+//@import "../bower_components/Styleguide/sass/components/quick-menu";
 //@import "../bower_components/Styleguide/sass/components/search-form";
+//@import "../bower_components/Styleguide/sass/components/search-toggle";
 //@import "../bower_components/Styleguide/sass/components/some-links";
 @import "../bower_components/Styleguide/sass/components/table";
 //@import "../bower_components/Styleguide/sass/components/tag-list";
 @import "../bower_components/Styleguide/sass/components/textarea";
+//@import "../bower_components/Styleguide/sass/components/video-player";
 
 //@import "../bower_components/Styleguide/sass/components/box/box-application";
 //@import "../bower_components/Styleguide/sass/components/box/box-card";
 @import "../bower_components/Styleguide/sass/components/box/box-data";
 //@import "../bower_components/Styleguide/sass/components/box/box-hero";
 //@import "../bower_components/Styleguide/sass/components/box/box-ingress";
+//@import "../bower_components/Styleguide/sass/components/box/box-liftup";
 //@import "../bower_components/Styleguide/sass/components/box/box-logo";
 @import "../bower_components/Styleguide/sass/components/box/box-story";
 //@import "../bower_components/Styleguide/sass/components/box/box-subsection";

--- a/common/src/scss/styleguide/_styleguide.scss
+++ b/common/src/scss/styleguide/_styleguide.scss
@@ -60,6 +60,7 @@
 //@import "../bower_components/Styleguide/sass/components/breadcrumbs";
 //@import "../bower_components/Styleguide/sass/components/carousel";
 //@import "../bower_components/Styleguide/sass/components/date";
+@import "../bower_components/Styleguide/sass/components/fatmenu";
 //@import "../bower_components/Styleguide/sass/components/feed-listing";
 //@import "../bower_components/Styleguide/sass/components/file";
 //@import "../bower_components/Styleguide/sass/components/form";

--- a/main/src/app/directives/header/pageNavigation/pageNavigation.html
+++ b/main/src/app/directives/header/pageNavigation/pageNavigation.html
@@ -54,10 +54,6 @@
     </nav>
     <nav class="fatmenu" ng-class="{'is-open': fatmenuOpen, 'is-slidein': fatmenuOpen}" click-outside="hideFatmenu()" outside-if-not="fatmenu-open">
       <ul class="menu">
-        <li class="is-lvl1 is-active fatmenu__front">
-          <span class="fatmenu__home"></span>
-          <a href="#" class="active">Etusivu</a>
-        </li>
         <li class="is-lvl1 is-expandable" ng-class="{'is-open': fatmenuOpen}">
           <ul class="menu">
             <li ng-repeat="link in fatmenuContent track by link.key" class="is-lvl2">

--- a/main/src/scss/opintoni/_page-navigation.scss
+++ b/main/src/scss/opintoni/_page-navigation.scss
@@ -56,5 +56,20 @@ $navigationHeight: 60px;
         top: 2px;
       }
     }
+    .fatmenu {
+      display: none;
+      left: 0;
+      top: $navigationHeight;
+      height: auto;
+      z-index: 10001;
+
+      &.is-open {
+        display: block;
+      }
+
+      > ul.menu {
+        height: 100%;
+      }
+    }
   }
 }

--- a/main/src/scss/opintoni/_page-navigation.scss
+++ b/main/src/scss/opintoni/_page-navigation.scss
@@ -33,46 +33,9 @@ $navigationHeight: 60px;
       height: 100%;
       position: relative;
     }
-
-    @include breakpoint($small) {
-      nav {
-        height: 100%;
-        border: none;
-      }
-      .fatmenu {
-        position: absolute;
-        top: $navigationHeight;
-        left: 0;
-        display: none;
-        height: auto;
-        z-index: 10001;
-
-        &.is-open {
-          display: block;
-        }
-
-        > ul.menu {
-          height: 100%;
-        }
-      }
-      .main-menu {
-        display: table;
-        height: 100%;
-      }
-      .main-menu__item {
-        display: table-cell;
-        vertical-align: middle;
-        font-weight: 700;
-        font-size: 15px;
-        letter-spacing: 0.01em;
-        text-transform: uppercase;
-        text-decoration: none;
-        &:first-child {
-          padding-right: 20px;
-          position: relative;
-          top: 2px;
-        }
-      }
+    nav {
+      height: 100%;
+      border: none;
     }
     .fatmenu {
       display: none;


### PR DESCRIPTION
Uusi yritys. Pakolliset säädöt .page-navigation.scss:n fatmenulle jottei se peitä menupalkkia ollessaan suljettuna. Myös lisätty _styleguide.scss:ään ne styleguiden palat jotka olisi saatavilla, mutta joita ei käytetä jotta olisi helpompaa korjata jos nähdään jonkun komponentin hajoavan.