### PR TITLE
OO-1466

### DIFF
--- a/common/src/scss/styleguide/_styleguide.scss
+++ b/common/src/scss/styleguide/_styleguide.scss
@@ -20,7 +20,10 @@
 @import "../bower_components/Styleguide/sass/variables/breakpoints";
 @import "../bower_components/Styleguide/sass/variables/colors";
 //@import "../bower_components/Styleguide/sass/variables/rasters";
-@import "../bower_components/Styleguide/sass/variables/typography";
+//@import "../bower_components/Styleguide/sass/variables/typography";
+$base-font-size-mobile: 14px;
+$base-font-size: 16px;
+
 @import "../bower_components/Styleguide/sass/mixins/angular";
 @import "../bower_components/Styleguide/sass/mixins/arrow";
 @import "../bower_components/Styleguide/sass/mixins/border";


### PR DESCRIPTION
OO-frontissa oli kaksi tapaa ladata Open Sans -fontit: 1) yrittää käyttää bower_componentsissa olevan Styleguiden mukana olevia, 2) ladata googlen fontteja `main/src/index.html`:ssä , siellä `  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700">
`. Sitten kun on vielä OBar mukana, niin sekin pyrkii määrittämään Open Sans -fontit ja jotenkin rikkoo (1):n. Otettiin (1) pois ja käytetään google-fontteja ja obar käyttää omiaan.  